### PR TITLE
chore: update Metabase to version 1.2.0 and changelog

### DIFF
--- a/.github/workflows/metabase.yml
+++ b/.github/workflows/metabase.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - 'master'
-      - 'metabase-1.1.1'
+      - 'metabase-1.2.0'
     tags:
       - '*.*.*'
     paths:
@@ -28,13 +28,13 @@ jobs:
           # AMD64
           - DOCKER_TAG_SUFFIX: amd64
             S6_ARCH: amd64
-            BASE_IMAGE: metabase/metabase:v0.53.9
+            BASE_IMAGE: metabase/metabase:v0.54.6.1
             PLATFORMS: linux/amd64
             QEMU_ARCH: x86_64
           # ARM64V8
           - DOCKER_TAG_SUFFIX: aarch64
             S6_ARCH: aarch64
-            BASE_IMAGE: metabase/metabase:v0.53.9
+            BASE_IMAGE: metabase/metabase:v0.54.6.1
             PLATFORMS: linux/arm64
             QEMU_ARCH: aarch64
     steps:

--- a/metabase/CHANGELOG.md
+++ b/metabase/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+- Update to Metabase 54.6.1
+
 ## 1.1.1
 
 - Update to Metabase 0.53.9

--- a/metabase/README.md
+++ b/metabase/README.md
@@ -35,7 +35,7 @@ See config instructions here: https://github.com/sanderdw/hassio-addons
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg?style=flat-square
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg?style=flat-square
-[metabase-shield]: https://img.shields.io/badge/Metabase%20Version-%200.53.9-purple.svg?style=flat-square
+[metabase-shield]: https://img.shields.io/badge/Metabase%20Version-%200.54.6.1-purple.svg?style=flat-square
 [addon-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2Fsanderdw%2Fhassio-addons%2Fraw%2Frefs%2Fheads%2Fmaster%2Fmetabase%2Fconfig.json&query=version&style=flat-square&label=Addon%20Version
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/t/metabase-add-on-for-home-assistant/286413

--- a/metabase/config.json
+++ b/metabase/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Metabase",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "slug": "metabase",
   "description": "Meet the easy, open source way for everyone to ask questions and learn from data.",
   "url": "https://github.com/sanderdw/hassio-addons/blob/master/metabase/README.md",


### PR DESCRIPTION
This pull request updates the Metabase add-on to version 1.2.0, reflecting changes in the base image, configuration, and documentation to align with the new version. Below are the most important changes grouped by theme:

### Workflow and Configuration Updates:
* Updated the GitHub Actions workflow to trigger on the `metabase-1.2.0` branch instead of `metabase-1.1.1`. (`.github/workflows/metabase.yml`, [.github/workflows/metabase.ymlL9-R9](diffhunk://#diff-0d3fc4c740dd8567e63c232409aa696b39256c937dd51ae1a5fe0aa45c931e8aL9-R9))
* Changed the base image for both AMD64 and ARM64 architectures from `metabase:v0.53.9` to `metabase:v0.54.6.1` in the workflow configuration. (`.github/workflows/metabase.yml`, [.github/workflows/metabase.ymlL31-R37](diffhunk://#diff-0d3fc4c740dd8567e63c232409aa696b39256c937dd51ae1a5fe0aa45c931e8aL31-R37))
* Updated the add-on version in `metabase/config.json` from `1.1.1` to `1.2.0`. (`metabase/config.json`, [metabase/config.jsonL3-R3](diffhunk://#diff-c08a2c034ba57e3b6627809440f7071d6c3df617d157f66a4351a39d0dfae93bL3-R3))

### Documentation Updates:
* Added a changelog entry for version 1.2.0, noting the update to Metabase 54.6.1. (`metabase/CHANGELOG.md`, [metabase/CHANGELOG.mdR3-R6](diffhunk://#diff-c8379175f9b96cc4588ff712437c7d774c2b9576cbbb4867cddfaec3e52d3563R3-R6))
* Updated the Metabase version badge in the README file to reflect version 0.54.6.1. (`metabase/README.md`, [metabase/README.mdL38-R38](diffhunk://#diff-090ee2c5d3a58ff1ac857d0808b7e1f1b00d17b65dd7bbd61b731339cd523f36L38-R38))