### PR TITLE
Change default TimescaleDB host in config

### DIFF
--- a/dsmr_reader/config.json
+++ b/dsmr_reader/config.json
@@ -36,7 +36,7 @@
     "DJANGO_DATABASE_NAME": "dsmrreader",
     "DJANGO_DATABASE_USER": "postgres",
     "DJANGO_DATABASE_PASSWORD": "homeassistant",
-    "DJANGO_DATABASE_HOST": "77b2833f-timescaledb",
+    "DJANGO_DATABASE_HOST": "1d11d3ee-timescaledb",
     "DJANGO_DATABASE_PORT": "5432",
     "CONTAINER_RUN_MODE": "standalone",
     "DSMRREADER_REMOTE_DATALOGGER_API_HOSTS": "http(s)://<YOUR_DSMR_HOST>:<PORT>",


### PR DESCRIPTION
Update DJANGO_DATABASE_HOST to use the current default TimescaleDB instance provided by Expaso. The previous host (77b2833f-timescaledb) is no longer valid, while 1d11d3ee-timescaledb has been the standard default for some time. This change ensures the application connects to a supported and active database endpoint.