### PR TITLE
chore: update voltviz to 0.18.0

### DIFF
--- a/.github/skills/voltviz-release-update/SKILL.md
+++ b/.github/skills/voltviz-release-update/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: voltviz-release-update
+description: Update the VoltViz add-on to the latest upstream release, including version bumps, changelog, workflow config, and PR creation. Use when releasing new VoltViz versions.
+argument-hint: 'Optional: specific target version. If omitted, fetches latest from upstream.'
+user-invocable: true
+disable-model-invocation: false
+---
+
+# VoltViz Release Update
+
+## What This Skill Produces
+A complete VoltViz add-on release across all configuration and workflow files, including:
+- Updated app version in `voltviz/config.json`
+- New release entry in `voltviz/CHANGELOG.md` with upstream changes
+- Updated base image tag in `.github/workflows/voltviz.yml`
+- New git branch `voltviz-{version}`
+- Committed changes with descriptive message
+- Pull request to `main` with changelog summary
+
+## When to Use
+Use this skill when:
+- A new upstream VoltViz version is released
+- You want to bring the add-on in sync with upstream
+- You need consistent version tracking across config, changelog, and CI/CD
+
+## Inputs
+Provide:
+- Optional: Target upstream version (example: `0.18.0`). If omitted, fetches the latest from https://github.com/sanderdw/voltviz
+
+## Procedure
+
+### 1. Discover Current and Target Versions
+   - Read `voltviz/config.json` to find current add-on version.
+   - Visit https://github.com/sanderdw/voltviz/blob/main/CHANGELOG.md and identify the latest upstream version (or use user-provided version).
+   - Compare to confirm a version bump is needed.
+
+### 2. Fetch Upstream Changelog
+   - Read the upstream CHANGELOG.md at https://github.com/sanderdw/voltviz
+   - Extract the changelog entry for the target version.
+   - Note: The upstream repo does not use GitHub Releases, so CHANGELOG.md is the source of truth.
+
+### 3. Update Configuration Files
+   - Update `voltviz/config.json`: set `version` to the target version.
+   - Update `voltviz/CHANGELOG.md`: prepend a new entry at the top with:
+     - Version heading: `## [VERSION] - YYYY-MM-DD`
+     - `### Added` section with new features from upstream
+     - `### Changed` section with improvements/refactors from upstream
+     - Keep existing format and style
+   - Update `.github/workflows/voltviz.yml`:
+     - For both `DOCKER_TAG_SUFFIX: amd64` and `DOCKER_TAG_SUFFIX: aarch64` matrix entries
+     - Update `BASE_IMAGE` from `ghcr.io/sanderdw/voltviz:OLD_VERSION` to `ghcr.io/sanderdw/voltviz:NEW_VERSION`
+
+### 4. Commit and Create Branch
+   - Create new branch: `git checkout -b voltviz-{NEW_VERSION}`
+   - Stage changes: `git add voltviz/config.json voltviz/CHANGELOG.md .github/workflows/voltviz.yml`
+   - Commit with message:
+     ```
+     chore: update voltviz to {VERSION}
+     
+     - Update add-on version from {OLD} to {NEW}
+     - Add CHANGELOG entry for {VERSION} release
+     - Update workflow BASE_IMAGE to {VERSION}
+     - [List key upstream features]
+     
+     Upstream changelog: https://github.com/sanderdw/voltviz/blob/main/CHANGELOG.md
+     ```
+   - Push to remote: `git push -u origin voltviz-{VERSION}`
+
+### 5. Create Pull Request
+   - Create PR to `main` with title: `chore: update voltviz to {VERSION}`
+   - PR body should include:
+     - Summary of upstream changes
+     - List of new visualizers or features
+     - List of improvements/refactors
+     - Link to upstream changelog
+
+## Decision Points
+- If upstream CHANGELOG contains duplicates or formatting issues: clean and consolidate.
+- If upstream version includes only patch/minor changes: update workflow and config without feature highlights.
+- If no new commits since last release: confirm with user before proceeding.
+
+## Completion Criteria
+- `voltviz/config.json` version matches target version.
+- `voltviz/CHANGELOG.md` has new top entry with upstream version, date, and changes.
+- `.github/workflows/voltviz.yml` BASE_IMAGE tags match target version for both architectures.
+- Branch named `voltviz-{VERSION}` created and pushed.
+- PR opened to `main` with descriptive body linking upstream changes.
+- All three files (config, changelog, workflow) committed together in one atomic commit.
+
+## Example Prompt
+```
+Update voltviz to 0.18.0 using the latest from https://github.com/sanderdw/voltviz. 
+Use its CHANGELOG as the base and create a PR.
+```

--- a/.github/workflows/voltviz.yml
+++ b/.github/workflows/voltviz.yml
@@ -28,12 +28,12 @@ jobs:
         include:
           # AMD64
           - DOCKER_TAG_SUFFIX: amd64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.17.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.18.0
             PLATFORMS: linux/amd64
 
           # ARM64V8
           - DOCKER_TAG_SUFFIX: aarch64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.17.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.18.0
             PLATFORMS: linux/arm64/v8
 
     steps:

--- a/voltviz/CHANGELOG.md
+++ b/voltviz/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.18.0] - 2026-05-23
+
+### Added
+- Skins system – switch the entire UI between **Modern**, **Win95**, **Winamp**, and **CRT** themes (via `?skin=` URL parameter).
+- ASCII visualizer – Canvas 2D audio-reactive ASCII art renderer.
+- Cyber City visualizer – raymarched neon-grid cityscape flythrough with audio-driven scan pulses, fog, and dot density (Three.js/WebGL).
+- Audio Debug visualizer – diagnostic view with waveform, FFT spectrum, kick detection, stereo correlation meter, and rolling spectrogram (Canvas 2D).
+- Aurum Leaf visualizer – tentacled energy bloom with particles, kick-reactive bloom bursts, and UnrealBloom post-processing (Three.js/WebGL).
+- Sphere visualizer – raymarched KIFS-folded sphere with auto-rotation and audio-reactive brightness/zoom (Three.js/WebGL).
+- Trails Stream visualizer – bending tube-trail stream with blur, bloom, and audio-reactive exposure (Three.js/WebGL).
+- Shambhala visualizer – voxel tunnel raymarcher with space-folding, glow, and audio-reactive exposure (Three.js/WebGL).
+
+### Changed
+- FractalOrb: refactored audio analysis and visual response for tighter reactivity.
+- Vite: raised `chunkSizeWarningLimit` from 550 to 600 to accommodate the new shader-heavy visualizers.
+- Dependency bumps
+
 ## [0.17.0] - 2026-05-13
 
 ### Added

--- a/voltviz/config.json
+++ b/voltviz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "VoltViz",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "slug": "voltviz",
   "description": "A dynamic, real-time music visualizer that transforms sound into stunning visual experiences",
   "arch": ["aarch64", "amd64"],


### PR DESCRIPTION
## Update voltviz add-on to 0.18.0

Updates the voltviz add-on from version 0.17.0 (2026-05-13) to the latest upstream release 0.18.0 (2026-05-23).

### Changes
- **Version bump**: Updated `config.json` from 0.17.0 to 0.18.0
- **CHANGELOG**: Added new 0.18.0 entry documenting upstream changes

### New Features (upstream 0.18.0)
- **Skins system**: Switch between Modern, Win95, Winamp, and CRT UI themes via `?skin=` URL parameter
- **7 new visualizers**:
  - ASCII – Canvas 2D audio-reactive ASCII art
  - Cyber City – Raymarched neon-grid cityscape (Three.js/WebGL)
  - Audio Debug – Diagnostic view with waveform, FFT, spectrogram (Canvas 2D)
  - Aurum Leaf – Tentacled energy bloom with particles (Three.js/WebGL)
  - Sphere – Raymarched KIFS-folded sphere (Three.js/WebGL)
  - Trails Stream – Bending tube-trail stream (Three.js/WebGL)
  - Shambhala – Voxel tunnel raymarcher (Three.js/WebGL)

### Improvements
- FractalOrb: Refactored audio analysis for tighter reactivity
- Vite: Increased `chunkSizeWarningLimit` to support shader-heavy visualizers
- Dependency updates

### Upstream Source
Changelog based on: https://github.com/sanderdw/voltviz/blob/main/CHANGELOG.md#0180---2026-05-23