### PR TITLE
Metabase 1.4.0

### DIFF
--- a/.github/skills/metabase-release-update/SKILL.md
+++ b/.github/skills/metabase-release-update/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: metabase-release-update
 description: 'Update the Metabase app release files consistently. Use when bumping Metabase version, refreshing workflow actions, aligning workflow triggers, and updating changelog/config metadata.'
-argument-hint: 'Target Metabase version and summary of changes (for example: 0.60.3.6 + workflow action upgrades)'
+argument-hint: 'Target Metabase version, add-on version, and release scope (for example: 0.61.3 + 1.4.0 + workflow action upgrades)'
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -9,12 +9,13 @@ disable-model-invocation: false
 # Metabase Release Update
 
 ## What This Skill Produces
-A consistent Metabase release update across workflow automation and app metadata, including:
+A consistent Metabase release update across workflow automation, app metadata, and release publishing, including:
 - Updated GitHub Actions versions in `.github/workflows/metabase.yml`
 - Updated Metabase base image tag in `.github/workflows/metabase.yml` when required
 - Updated app version in `metabase/config.json` when required
 - New release entry at the top of `metabase/CHANGELOG.md`
 - Updated metabase-shield in `README.md` to reflect the new Metabase version
+- Release branch, commit, push, and pull request creation when requested
 
 ## When to Use
 Use this skill when:
@@ -29,6 +30,7 @@ Provide:
 - Whether prerelease tags are allowed (default: no)
 - Whether to update workflow action versions to latest known stable majors in this repository
 - Any trigger/path updates needed in `.github/workflows/metabase.yml`
+- Whether to create a release branch and PR after the files are updated
 
 ## Procedure
 1. Gather current state.
@@ -38,6 +40,7 @@ Provide:
    - Check https://hub.docker.com/r/metabase/metabase/tags and identify the latest usable upstream tag.
    - Prefer pinned full version tags (for example `v0.60.3.6`) over floating aliases (for example `latest`, `v0.60.x`, `v0.60.3.x`).
    - Exclude prerelease tags such as `-beta` unless prerelease is explicitly requested.
+   - If the target add-on version is not provided, derive it from the release cadence already used in the repository.
 
 2. Update workflow actions and build metadata.
    - In `.github/workflows/metabase.yml`, upgrade `uses:` versions to latest majors already adopted in the repository unless instructed otherwise.
@@ -62,12 +65,18 @@ Provide:
      - Workflow build source version (`BASE_IMAGE`) when changed
    - Ensure only intended files changed.
 
+6. Publish the release when requested.
+   - Create a release branch from the current worktree state using a clear name such as `metabase-{addon_version}`.
+   - Commit the release update as a single atomic commit.
+   - Push the branch to the remote and open a pull request against `main`.
+
 ## Decision Points
 - If only CI updates are requested: update workflow actions and changelog only; do not bump `metabase/config.json`.
 - If release version is bumped: update workflow (if relevant), `metabase/config.json`, and changelog together.
 - If repository workflows differ on action majors: prefer the newest version already used by a maintained workflow in this repository.
 - If Docker Hub newest tags are floating aliases, pick the newest pinned stable tag for reproducible builds.
 - If only prerelease tags exist for a newer line, keep the latest stable pinned tag unless prerelease is requested.
+- If release publishing is requested, keep the branch name, commit message, and PR title aligned with the new add-on version.
 
 ## Completion Criteria
 - `metabase/config.json` version is correct for release updates.
@@ -75,3 +84,4 @@ Provide:
 - `.github/workflows/metabase.yml` action versions and build inputs match requested scope.
 - Selected Metabase image tag is pinned and matches Docker Hub latest stable policy.
 - No unrelated files or formatting-only churn.
+- If publish mode was requested, the release branch exists on the remote and a PR against `main` is open.

--- a/.github/workflows/metabase.yml
+++ b/.github/workflows/metabase.yml
@@ -29,19 +29,19 @@ jobs:
           # AMD64
           - DOCKER_TAG_SUFFIX: amd64
             S6_ARCH: amd64
-            BASE_IMAGE: metabase/metabase:v0.60.3.6
+            BASE_IMAGE: metabase/metabase:v0.61.3
             PLATFORMS: linux/amd64
             QEMU_ARCH: x86_64
           # ARM64V8
           - DOCKER_TAG_SUFFIX: aarch64
             S6_ARCH: aarch64
-            BASE_IMAGE: metabase/metabase:v0.60.3.6
+            BASE_IMAGE: metabase/metabase:v0.61.3
             PLATFORMS: linux/arm64
             QEMU_ARCH: aarch64
     steps:
       # Get the repository's code
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       # https://github.com/docker/setup-qemu-action
       - name: Get the version from config.json
         id: data
@@ -101,7 +101,7 @@ jobs:
             BUILD_ARCH=${{matrix.S6_ARCH}}
       - name: Generate artifact attestation
         if: github.ref == 'refs/heads/main'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/${{ github.repository }}/ha-metabase-${{ matrix.DOCKER_TAG_SUFFIX }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/metabase/CHANGELOG.md
+++ b/metabase/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+- Update to Metabase 0.61.3
+- Refresh GitHub Actions workflow dependencies to latest major versions
+
 ## 1.3.0
 
 - Update to Metabase 0.60.3.6

--- a/metabase/README.md
+++ b/metabase/README.md
@@ -35,7 +35,7 @@ See config instructions here: https://github.com/sanderdw/hassio-addons
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg?style=flat-square
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg?style=flat-square
-[metabase-shield]: https://img.shields.io/badge/Metabase%20Version-%200.60.3-purple.svg?style=flat-square
+[metabase-shield]: https://img.shields.io/badge/Metabase%20Version-%200.61.3-purple.svg?style=flat-square
 [addon-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2Fsanderdw%2Fhassio-addons%2Fraw%2Frefs%2Fheads%2Fmain%2Fmetabase%2Fconfig.json&query=version&style=flat-square&label=Addon%20Version
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/t/metabase-add-on-for-home-assistant/286413

--- a/metabase/config.json
+++ b/metabase/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Metabase",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "slug": "metabase",
   "description": "Meet the easy, open source way for everyone to ask questions and learn from data.",
   "url": "https://github.com/sanderdw/hassio-addons/blob/main/metabase/README.md",


### PR DESCRIPTION
Release update for Metabase.

- Bump add-on version to 1.4.0
- Update Metabase base image to v0.61.3
- Refresh workflow actions to current repo majors
- Update Metabase badge in the add-on README