### PR TITLE
chore: update voltviz to 0.19.1

### DIFF
--- a/.github/skills/voltviz-release-update/SKILL.md
+++ b/.github/skills/voltviz-release-update/SKILL.md
@@ -42,7 +42,7 @@ Provide:
 ### 3. Update Configuration Files
    - Update `voltviz/config.json`: set `version` to the target version.
    - Update `voltviz/CHANGELOG.md`: prepend a new entry at the top with:
-     - Version heading: `## [VERSION] - YYYY-MM-DD`
+     - Version heading: `## [VERSION] - YYYY-MM-DD` (use today's date — the date the add-on is released — not the upstream release date)
      - `### Added` section with new features from upstream
      - `### Changed` section with improvements/refactors from upstream
      - Keep existing format and style

--- a/.github/workflows/voltviz.yml
+++ b/.github/workflows/voltviz.yml
@@ -28,12 +28,12 @@ jobs:
         include:
           # AMD64
           - DOCKER_TAG_SUFFIX: amd64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.18.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.19.1
             PLATFORMS: linux/amd64
 
           # ARM64V8
           - DOCKER_TAG_SUFFIX: aarch64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.18.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.19.1
             PLATFORMS: linux/arm64/v8
 
     steps:

--- a/voltviz/CHANGELOG.md
+++ b/voltviz/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.19.1] - 2026-06-17
+
+### Added
+- Holo Blinds visualizer – raymarched twisting gyroid confined to a squashed sphere core with audio-reactive brightness, twist speed, and detail (Three.js/WebGL).
+- Inside Quantum visualizer – full-screen KIFS fractal with volumetric raymarching, asymmetric folding, domain warping, and accumulated glow (Three.js/WebGL). Audio-reactive warp amplitude, rotation speed, and ray thickness.
+
+### Changed
+- Dependency bumps
+
 ## [0.18.0] - 2026-05-23
 
 ### Added

--- a/voltviz/config.json
+++ b/voltviz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "VoltViz",
-  "version": "0.18.0",
+  "version": "0.19.1",
   "slug": "voltviz",
   "description": "A dynamic, real-time music visualizer that transforms sound into stunning visual experiences",
   "arch": ["aarch64", "amd64"],


### PR DESCRIPTION
## Update VoltViz add-on to 0.19.1

Updates the VoltViz add-on from `0.18.0` to `0.19.1`.

### New Visualizers
- **Holo Blinds** – raymarched twisting gyroid confined to a squashed sphere core with audio-reactive brightness, twist speed, and detail (Three.js/WebGL).
- **Inside Quantum** – full-screen KIFS fractal with volumetric raymarching, asymmetric folding, domain warping, and accumulated glow (Three.js/WebGL). Audio-reactive warp amplitude, rotation speed, and ray thickness.

### Improvements
- Dependency bumps

### Changes in this PR
- `voltviz/config.json`: version bumped to `0.19.1`
- `voltviz/CHANGELOG.md`: added `0.19.1` release entry
- `.github/workflows/voltviz.yml`: updated `BASE_IMAGE` to `ghcr.io/sanderdw/voltviz:0.19.1` for both architectures
- `.github/skills/voltviz-release-update/SKILL.md`: clarified that changelog date should use the current day (add-on release date)

### Upstream changelog
https://github.com/sanderdw/voltviz/blob/main/CHANGELOG.md