### PR TITLE
chore: update voltviz to 0.20.0

### DIFF
--- a/.github/workflows/voltviz.yml
+++ b/.github/workflows/voltviz.yml
@@ -28,12 +28,12 @@ jobs:
         include:
           # AMD64
           - DOCKER_TAG_SUFFIX: amd64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.19.1
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.20.0
             PLATFORMS: linux/amd64
 
           # ARM64V8
           - DOCKER_TAG_SUFFIX: aarch64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.19.1
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.20.0
             PLATFORMS: linux/arm64/v8
 
     steps:

--- a/voltviz/CHANGELOG.md
+++ b/voltviz/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.20.0] - 2026-07-06
+
+### Added
+- Particles Stream visualizer - flies a luma-sliced pixel-particle field of the album artwork toward the camera with afterimage motion blur; bass-reactive speed and brightness, with image upload (Three.js/WebGL).
+
+### Changed
+- Dependency bumps
+
 ## [0.19.1] - 2026-06-17
 
 ### Added

--- a/voltviz/config.json
+++ b/voltviz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "VoltViz",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "slug": "voltviz",
   "description": "A dynamic, real-time music visualizer that transforms sound into stunning visual experiences",
   "arch": ["aarch64", "amd64"],


### PR DESCRIPTION
## Summary
- Update VoltViz add-on from `0.19.1` to `0.20.0`
- Sync add-on changelog with upstream `0.20.0`
- Update workflow base image tags to `ghcr.io/sanderdw/voltviz:0.20.0` for `amd64` and `aarch64`

## Upstream changes in 0.20.0
### Added
- Particles Stream visualizer: luma-sliced album-art pixel particles flying toward camera with afterimage motion blur, bass-reactive speed/brightness, and image upload support.

### Changed
- Dependency bumps

Upstream changelog: https://github.com/sanderdw/voltviz/blob/main/CHANGELOG.md
