### PR TITLE
chore: update voltviz to 0.21.0

### DIFF
--- a/.github/workflows/voltviz.yml
+++ b/.github/workflows/voltviz.yml
@@ -28,12 +28,12 @@ jobs:
         include:
           # AMD64
           - DOCKER_TAG_SUFFIX: amd64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.20.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.21.0
             PLATFORMS: linux/amd64
 
           # ARM64V8
           - DOCKER_TAG_SUFFIX: aarch64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.20.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.21.0
             PLATFORMS: linux/arm64/v8
 
     steps:

--- a/voltviz/CHANGELOG.md
+++ b/voltviz/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.21.0] - 2026-08-01
+
+### Added
+- Visualizer gallery picker – the header dropdown is replaced by a modal with preview screenshot cards for every visualizer.
+- Shuffle mode – toggle in the settings panel that switches to a random visualizer at a selectable interval (15s–10m), persisted via `shuffle`/`shuffleTime` URL params.
+- Seamless crossfade between visualizers – the previous visualizer keeps rendering while the next one loads and warms up, then fades in; applies to shuffle switches and manual selection.
+- Transition style setting (Crossfade / Quick cut / Instant) in the settings panel, persisted via the `transition` URL param – lighter modes for low-end hardware.
+- Sungalizer visualizer – retro amber-phosphor CRT quad analyzer: 2D spectrum, 3D depth-trace waterfall, scrolling spectrogram, and oscilloscope, plus a hardware-style side panel with reactive VU needle and knobs (Canvas 2D).
+
+### Changed
+- Visualizer registration consolidated into a single manifest; new visualizers need just one entry plus a generated thumbnail.
+- Dependency bumps
+
 ## [0.20.0] - 2026-07-06
 
 ### Added

--- a/voltviz/config.json
+++ b/voltviz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "VoltViz",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "slug": "voltviz",
   "description": "A dynamic, real-time music visualizer that transforms sound into stunning visual experiences",
   "arch": ["aarch64", "amd64"],


### PR DESCRIPTION
## Summary
Updates the VoltViz add-on from 0.20.0 to upstream release 0.21.0.

### Added
- Visualizer gallery picker – the header dropdown is replaced by a modal with preview screenshot cards for every visualizer.
- Shuffle mode – switches to a random visualizer at a selectable interval (15s–10m), persisted via `shuffle`/`shuffleTime` URL params.
- Seamless crossfade between visualizers – the previous visualizer keeps rendering while the next one loads, then fades in.
- Transition style setting (Crossfade / Quick cut / Instant), persisted via the `transition` URL param – lighter modes for low-end hardware.
- Sungalizer visualizer – retro amber-phosphor CRT quad analyzer: 2D spectrum, 3D depth-trace waterfall, scrolling spectrogram, and oscilloscope (Canvas 2D).

### Changed
- Visualizer registration consolidated into a single manifest.
- Dependency bumps.

## Changes in this PR
- `voltviz/config.json`: version 0.20.0 → 0.21.0
- `voltviz/CHANGELOG.md`: new 0.21.0 entry
- `.github/workflows/voltviz.yml`: BASE_IMAGE → `ghcr.io/sanderdw/voltviz:0.21.0` (amd64 + aarch64)

Upstream changelog: https://github.com/sanderdw/voltviz/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)