### PR TITLE
chore: update voltviz to 0.21.1

### DIFF
--- a/.github/workflows/voltviz.yml
+++ b/.github/workflows/voltviz.yml
@@ -28,12 +28,12 @@ jobs:
         include:
           # AMD64
           - DOCKER_TAG_SUFFIX: amd64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.21.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.21.1
             PLATFORMS: linux/amd64
 
           # ARM64V8
           - DOCKER_TAG_SUFFIX: aarch64
-            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.21.0
+            BASE_IMAGE: ghcr.io/sanderdw/voltviz:0.21.1
             PLATFORMS: linux/arm64/v8
 
     steps:

--- a/voltviz/CHANGELOG.md
+++ b/voltviz/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.21.1] - 2026-08-01
+
+### Fixed
+- Visualizer preview thumbnails in the gallery picker now load correctly through Home Assistant ingress (upstream now builds with relative asset URLs).
+
 ## [0.21.0] - 2026-08-01
 
 ### Added

--- a/voltviz/config.json
+++ b/voltviz/config.json
@@ -1,6 +1,6 @@
 {
   "name": "VoltViz",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "slug": "voltviz",
   "description": "A dynamic, real-time music visualizer that transforms sound into stunning visual experiences",
   "arch": ["aarch64", "amd64"],


### PR DESCRIPTION
## Summary
Updates the VoltViz add-on from 0.21.0 to upstream release 0.21.1.

### Fixed
- Visualizer preview thumbnails in the gallery picker now load correctly through Home Assistant ingress. Upstream 0.21.0 inlined absolute `/assets/*.jpg` URLs into the JS bundle, which resolved outside the ingress prefix and 404'd; 0.21.1 builds with a relative Vite base (sanderdw/voltviz#19).

## Changes in this PR
- `voltviz/config.json`: version 0.21.0 → 0.21.1
- `voltviz/CHANGELOG.md`: new 0.21.1 entry
- `.github/workflows/voltviz.yml`: BASE_IMAGE → `ghcr.io/sanderdw/voltviz:0.21.1` (amd64 + aarch64)

Upstream changelog: https://github.com/sanderdw/voltviz/blob/main/CHANGELOG.md